### PR TITLE
removed quotes surrounding %q

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -71,7 +71,7 @@ func TestParseURL(t *testing.T) {
 		t.Run(c.u, func(t *testing.T) {
 			o, err := ParseURL(c.u)
 			if c.err == nil && err != nil {
-				t.Fatalf("unexpected error: '%q'", err)
+				t.Fatalf("unexpected error: %q", err)
 				return
 			}
 			if c.err != nil && err != nil {


### PR DESCRIPTION
%q is a single-quoted character literal safely escaped with Go syntax. It doesn't need additional quotes.